### PR TITLE
Mesh cutter wasm

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,11 +28,14 @@ export default () => {
 
     const map = new THREE.TextureLoader().load('https://raw.githubusercontent.com/gonnavis/annihilate/1a8536dc019924454a0fc7774a7dfa95a70aed92/image/uv_grid_opengl.jpg')
 
-    const geometry = new THREE.BoxGeometry(1, 1, 1)
+    // const geometry = new THREE.BoxGeometry(1, 1, 1)
+    const geometry = new THREE.TorusKnotGeometry(); geometry.scale(0.5, 0.5, 0.5);
     // const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
     const material = new THREE.MeshStandardMaterial({ map })
     const cube = new THREE.Mesh(geometry, material)
     window.cube = cube
+    cube.castShadow = true
+    cube.receiveShadow = true
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
     //cube =  new THREE.Mesh( new THREE.TetrahedronGeometry( 0.5, 0 ), material );
     cube.position.set(5, 1, 0)
@@ -101,10 +104,11 @@ export default () => {
     geometry2.setAttribute('uv', new THREE.Float32BufferAttribute(uvs1, 2))
 
     // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
-    const material2 = new THREE.MeshStandardMaterial({ map, side: THREE.DoubleSide })
-    const cube2 = new THREE.Mesh(geometry2, material2)
+    const cube2 = new THREE.Mesh(geometry2, cube.material)
     window.cube2 = cube2
-    cube2.position.set(0, 1, 0)
+    cube2.castShadow = true
+    cube2.receiveShadow = true
+    cube2.position.set(-1, 1, 0)
     console.log('geometry2', geometry2)
 
     //debugger;
@@ -120,10 +124,11 @@ export default () => {
     geometry3.setAttribute('uv', new THREE.Float32BufferAttribute(uvs2, 2))
 
     // const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
-    const material3 = new THREE.MeshStandardMaterial({ map, side: THREE.DoubleSide })
-    const cube3 = new THREE.Mesh(geometry3, material3)
+    const cube3 = new THREE.Mesh(geometry3, cube.material)
     window.cube3 = cube3
-    cube3.position.set(0, 1, 0)
+    cube3.castShadow = true
+    cube3.receiveShadow = true
+    cube3.position.set(0, 1, )
     console.log('geometry3', geometry3)
 
     app.add(cube3)

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ export default () => {
 
     console.log('-parameter positions: ', geometry.attributes.position.array)
     console.log('-parameter numPositions: ', geometry.attributes.position.count * 3)
+    console.log('-parameter normals: ', geometry.attributes.normal.array)
+    console.log('-parameter numNormals: ', geometry.attributes.normal.count * 3)
     console.log('-parameter faces: ', index.array)
     console.log('-parameter numFaces: ', index.count)
     console.log('-parameter position: ', planePosition)
@@ -63,6 +65,7 @@ export default () => {
       geometry.attributes.normal.count * 3, 
       index.array, 
       index.count, 
+
       planePosition, 
       planeQuaternion, 
       planeScale

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ export default () => {
     // const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
     const material = new THREE.MeshStandardMaterial({ map })
     const cube = new THREE.Mesh(geometry, material)
-    window.cube = cube
     cube.castShadow = true
     cube.receiveShadow = true
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
@@ -94,9 +93,6 @@ export default () => {
     const uvs1 = res.outUvs.slice(0, res.numOutUvs[0])
     const uvs2 = res.outUvs.slice(res.numOutUvs[0], res.numOutUvs[0] + res.numOutUvs[1])
 
-    const faces1 = res.outFaces.slice(0, res.numOutFaces[0])
-    const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
-
     const geometry2 = new THREE.BufferGeometry()
     // geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
@@ -105,11 +101,10 @@ export default () => {
 
     // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
     const cube2 = new THREE.Mesh(geometry2, cube.material)
-    window.cube2 = cube2
     cube2.castShadow = true
     cube2.receiveShadow = true
     cube2.position.set(-1, 1, 0)
-    console.log('geometry2', geometry2)
+    // console.log('geometry2', geometry2)
 
     //debugger;
 
@@ -125,11 +120,10 @@ export default () => {
 
     // const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
     const cube3 = new THREE.Mesh(geometry3, cube.material)
-    window.cube3 = cube3
     cube3.castShadow = true
     cube3.receiveShadow = true
     cube3.position.set(0, 1, )
-    console.log('geometry3', geometry3)
+    // console.log('geometry3', geometry3)
 
     app.add(cube3)
 

--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ export default () => {
     physicsIds.push(physicsId);
 */
 
+    const map = new THREE.TextureLoader().load('https://raw.githubusercontent.com/gonnavis/annihilate/1a8536dc019924454a0fc7774a7dfa95a70aed92/image/uv_grid_opengl.jpg')
+
     const geometry = new THREE.BoxGeometry(1, 1, 1)
     // const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
-    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
+    const material = new THREE.MeshStandardMaterial({ map })
     const cube = new THREE.Mesh(geometry, material)
     window.cube = cube
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
@@ -54,6 +56,8 @@ export default () => {
     console.log('-parameter numPositions: ', geometry.attributes.position.count * 3)
     console.log('-parameter normals: ', geometry.attributes.normal.array)
     console.log('-parameter numNormals: ', geometry.attributes.normal.count * 3)
+    console.log('-parameter uvs: ', geometry.attributes.uv.array)
+    console.log('-parameter numUvs: ', geometry.attributes.uv.count * 2)
     console.log('-parameter faces: ', index.array)
     console.log('-parameter numFaces: ', index.count)
     console.log('-parameter position: ', planePosition)
@@ -64,6 +68,8 @@ export default () => {
       geometry.attributes.position.count * 3, 
       geometry.attributes.normal.array, 
       geometry.attributes.normal.count * 3, 
+      geometry.attributes.uv.array,
+      geometry.attributes.uv.count * 2,
       index.array, 
       index.count, 
 
@@ -82,6 +88,9 @@ export default () => {
     const normals1 = res.outNormals.slice(0, res.numOutNormals[0])
     const normals2 = res.outNormals.slice(res.numOutNormals[0], res.numOutNormals[0] + res.numOutNormals[1])
 
+    const uvs1 = res.outUvs.slice(0, res.numOutUvs[0])
+    const uvs2 = res.outUvs.slice(res.numOutUvs[0], res.numOutUvs[0] + res.numOutUvs[1])
+
     const faces1 = res.outFaces.slice(0, res.numOutFaces[0])
     const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
 
@@ -89,9 +98,10 @@ export default () => {
     geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
     geometry2.setAttribute('normal', new THREE.Float32BufferAttribute(normals1, 3))
+    geometry2.setAttribute('uv', new THREE.Float32BufferAttribute(uvs1, 2))
 
     // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
-    const material2 = new THREE.MeshStandardMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
+    const material2 = new THREE.MeshStandardMaterial({ map, side: THREE.DoubleSide })
     const cube2 = new THREE.Mesh(geometry2, material2)
     window.cube2 = cube2
     cube2.position.set(0, 1, 0)
@@ -107,9 +117,10 @@ export default () => {
     geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
     geometry3.setAttribute('position', new THREE.Float32BufferAttribute(positions2, 3))
     geometry3.setAttribute('normal', new THREE.Float32BufferAttribute(normals2, 3))
+    geometry3.setAttribute('uv', new THREE.Float32BufferAttribute(uvs2, 2))
 
     // const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
-    const material3 = new THREE.MeshStandardMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
+    const material3 = new THREE.MeshStandardMaterial({ map, side: THREE.DoubleSide })
     const cube3 = new THREE.Mesh(geometry3, material3)
     window.cube3 = cube3
     cube3.position.set(0, 1, 0)

--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
-import * as THREE from 'three';
-import metaversefile from 'metaversefile';
-import { clamp } from 'three/src/math/MathUtils.js';
-const {useApp, useLoaders, useFrame, useActivate, useWear, useUse, useLocalPlayer, usePhysics, useScene, getNextInstanceId, getAppByPhysicsId, useWorld, useDefaultModules, useCleanup} = metaversefile;
+import * as THREE from 'three'
+import metaversefile from 'metaversefile'
+import { clamp } from 'three/src/math/MathUtils.js'
+const { useApp, useLoaders, useFrame, useActivate, useWear, useUse, useLocalPlayer, usePhysics, useScene, getNextInstanceId, getAppByPhysicsId, useWorld, useDefaultModules, useCleanup } = metaversefile
 
-const baseUrl = import.meta.url.replace(/(\/)[^\/\\]*$/, '$1');
-
+const baseUrl = import.meta.url.replace(/(\/)[^\/\\]*$/, '$1')
 
 export default () => {
-  const app = useApp();
-  const physics = usePhysics();
+  const app = useApp()
+  const physics = usePhysics()
 
-  let physicsIds = [];
-  (async () => {
+  let physicsIds = []
+  ;(async () => {
     /*const u = `${baseUrl}sword.glb`;
     let o = await new Promise((accept, reject) => {
       const {gltfLoader} = useLoaders();
@@ -27,98 +26,83 @@ export default () => {
     physicsIds.push(physicsId);
 */
 
-    const geometry = new THREE.BoxGeometry( 1, 1, 1 );
-    const material = new THREE.MeshBasicMaterial( {color: 0xff0000} );
-    const cube = new THREE.Mesh( geometry, material );
+    const geometry = new THREE.BoxGeometry(1, 1, 1)
+    const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    const cube = new THREE.Mesh(geometry, material)
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
     //cube =  new THREE.Mesh( new THREE.TetrahedronGeometry( 0.5, 0 ), material );
-    cube.position.set(2,1,0);
-    
+    cube.position.set(2, 1, 0)
 
-    app.add(cube);
+    app.add(cube)
 
-    cube.updateMatrixWorld();
+    cube.updateMatrixWorld()
 
+    const attrPos = cube.geometry.getAttribute('position')
+    const planePosition = new THREE.Vector3(0, 0, 0)
+    const planeQuaternion = new THREE.Quaternion(0, 1, 0, 0)
+    const planeScale = new THREE.Vector3(1, 1, 1)
 
+    planeQuaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI * 0.2)
 
-    const attrPos = cube.geometry.getAttribute( 'position' ); 
-    const planePosition = new THREE.Vector3(0,0,0);
-    const planeQuaternion = new THREE.Quaternion(0,1,0,0);
-    const planeScale = new THREE.Vector3(1,1,1);
+    const index = cube.geometry.getIndex()
 
-    planeQuaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI*0.2);
+    const res = physics.cutMesh(attrPos.array, attrPos.count * 3, index.array, index.count, planePosition, planeQuaternion, planeScale)
 
-    const index = cube.geometry.getIndex();
+    console.log(res)
 
-    const res = physics.cutMesh(attrPos.array,attrPos.count * 3,index.array,index.count,planePosition,planeQuaternion,planeScale);
+    console.log(physics)
 
-    console.log(res);
+    const positions1 = res.outPositions.slice(0, res.numOutPositions[0])
+    const positions2 = res.outPositions.slice(res.numOutPositions[0], res.numOutPositions[0] + res.numOutPositions[1])
 
+    const faces1 = res.outFaces.slice(0, res.numOutFaces[0])
+    const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
 
-    console.log(physics);
+    const geometry2 = new THREE.BufferGeometry()
 
-    const positions1 = res.outPositions.slice(0, res.numOutPositions[0]);
-    const positions2 = res.outPositions.slice(res.numOutPositions[0], res.numOutPositions[0] + res.numOutPositions[1]);
-    
-    const faces1 = res.outFaces.slice(0, res.numOutFaces[0]);
-    const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1]);
-    
-    
-    const geometry2 = new THREE.BufferGeometry();
-    
-    //geometry2.setIndex(faces1); 
+    //geometry2.setIndex(faces1);
     //geometry2.setAttribute('position', positions1);
-    
-    geometry2.setIndex(new THREE.Uint32BufferAttribute( faces1, 1 )); 
-    
-    geometry2.setAttribute('position', new THREE.Float32BufferAttribute( positions1, 3 ));
-    
-    const material2 = new THREE.MeshBasicMaterial( {color: 0x00ff00, side: THREE.DoubleSide} );
-    const cube2 = new THREE.Mesh( geometry2, material2 );
-    cube2.position.set(-0.2,1.1,0);
-    
+
+    geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
+
+    geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
+
+    const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
+    const cube2 = new THREE.Mesh(geometry2, material2)
+    cube2.position.set(-0.2, 1.1, 0)
+
     //debugger;
-    
-    app.add( cube2 );
 
-    cube2.updateMatrixWorld();
-    
-    
-    const geometry3 = new THREE.BufferGeometry();
-    geometry3.setIndex(new THREE.Uint32BufferAttribute( faces2, 1 )); 
-    geometry3.setAttribute('position', new THREE.Float32BufferAttribute( positions2, 3 ));
-    
-    const material3 = new THREE.MeshBasicMaterial( {color: 0x0000ff, side: THREE.DoubleSide} );
-    const cube3 = new THREE.Mesh( geometry3, material3 );
-    cube3.position.set(0.2,0.9,0);
-    
-    
-    app.add( cube3 );
+    app.add(cube2)
 
-    cube3.updateMatrixWorld();
+    cube2.updateMatrixWorld()
 
-    
-  })();
+    const geometry3 = new THREE.BufferGeometry()
+    geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
+    geometry3.setAttribute('position', new THREE.Float32BufferAttribute(positions2, 3))
 
-  useWear(e => {
-    
-    console.log("useWear");
-  });
+    const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
+    const cube3 = new THREE.Mesh(geometry3, material3)
+    cube3.position.set(0.2, 0.9, 0)
 
-  useUse(e => {
+    app.add(cube3)
 
+    cube3.updateMatrixWorld()
+  })()
 
-    console.log("useUse");
+  useWear((e) => {
+    console.log('useWear')
+  })
 
+  useUse((e) => {
+    console.log('useUse')
+  })
 
-    
-  });
-  
   useCleanup(() => {
     for (const physicsId of physicsIds) {
-      physics.removeGeometry(physicsId);
+      physics.removeGeometry(physicsId)
     }
-  });
+  })
 
-  return app;
-};
+  return app
+}

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ export default () => {
     const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
 
     const geometry2 = new THREE.BufferGeometry()
-    geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
+    // geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
     geometry2.setAttribute('normal', new THREE.Float32BufferAttribute(normals1, 3))
     geometry2.setAttribute('uv', new THREE.Float32BufferAttribute(uvs1, 2))
@@ -114,7 +114,7 @@ export default () => {
     cube2.updateMatrixWorld()
 
     const geometry3 = new THREE.BufferGeometry()
-    geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
+    // geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
     geometry3.setAttribute('position', new THREE.Float32BufferAttribute(positions2, 3))
     geometry3.setAttribute('normal', new THREE.Float32BufferAttribute(normals2, 3))
     geometry3.setAttribute('uv', new THREE.Float32BufferAttribute(uvs2, 2))

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ export default () => {
 */
 
     const geometry = new THREE.BoxGeometry(1, 1, 1)
-    const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    // const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
     const cube = new THREE.Mesh(geometry, material)
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
     //cube =  new THREE.Mesh( new THREE.TetrahedronGeometry( 0.5, 0 ), material );
@@ -37,7 +38,7 @@ export default () => {
 
     cube.updateMatrixWorld()
 
-    const attrPos = cube.geometry.getAttribute('position')
+    // const attrPos = cube.geometry.getAttribute('position')
     const planePosition = new THREE.Vector3(0, 0, 0)
     const planeQuaternion = new THREE.Quaternion(0, 1, 0, 0)
     const planeScale = new THREE.Vector3(1, 1, 1)
@@ -46,7 +47,24 @@ export default () => {
 
     const index = cube.geometry.getIndex()
 
-    const res = physics.cutMesh(attrPos.array, attrPos.count * 3, index.array, index.count, planePosition, planeQuaternion, planeScale)
+    console.log('-geometry: ', geometry)
+
+    console.log('-parameter positions: ', geometry.attributes.position.array)
+    console.log('-parameter numPositions: ', geometry.attributes.position.count * 3)
+    console.log('-parameter faces: ', index.array)
+    console.log('-parameter numFaces: ', index.count)
+    console.log('-parameter position: ', planePosition)
+    console.log('-parameter quaternion: ', planeQuaternion)
+    console.log('-parameter scale: ', planeScale)
+    const res = physics.cutMesh(
+      geometry.attributes.position.array, 
+      geometry.attributes.position.count * 3, 
+      index.array, 
+      index.count, 
+      planePosition, 
+      planeQuaternion, 
+      planeScale
+    )
 
     console.log(res)
 
@@ -67,9 +85,11 @@ export default () => {
 
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
 
-    const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
+    // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
+    const material2 = new THREE.MeshStandardMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
     const cube2 = new THREE.Mesh(geometry2, material2)
     cube2.position.set(-0.2, 1.1, 0)
+    console.log('geometry2', geometry2)
 
     //debugger;
 
@@ -81,9 +101,11 @@ export default () => {
     geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
     geometry3.setAttribute('position', new THREE.Float32BufferAttribute(positions2, 3))
 
-    const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
+    // const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
+    const material3 = new THREE.MeshStandardMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
     const cube3 = new THREE.Mesh(geometry3, material3)
     cube3.position.set(0.2, 0.9, 0)
+    console.log('geometry3', geometry3)
 
     app.add(cube3)
 

--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ export default () => {
     const res = physics.cutMesh(
       geometry.attributes.position.array, 
       geometry.attributes.position.count * 3, 
+      geometry.attributes.normal.array, 
+      geometry.attributes.normal.count * 3, 
       index.array, 
       index.count, 
       planePosition, 
@@ -73,6 +75,9 @@ export default () => {
     const positions1 = res.outPositions.slice(0, res.numOutPositions[0])
     const positions2 = res.outPositions.slice(res.numOutPositions[0], res.numOutPositions[0] + res.numOutPositions[1])
 
+    const normals1 = res.outNormals.slice(0, res.numOutNormals[0])
+    const normals2 = res.outNormals.slice(res.numOutNormals[0], res.numOutNormals[0] + res.numOutNormals[1])
+
     const faces1 = res.outFaces.slice(0, res.numOutFaces[0])
     const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
 
@@ -84,6 +89,7 @@ export default () => {
     geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
 
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
+    geometry2.setAttribute('normal', new THREE.Float32BufferAttribute(normals1, 3))
 
     // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
     const material2 = new THREE.MeshStandardMaterial({ color: 0x00ff00, side: THREE.DoubleSide })

--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ export default () => {
     // const material = new THREE.MeshBasicMaterial({ color: 0xff0000 })
     const material = new THREE.MeshStandardMaterial({ color: 0xff0000 })
     const cube = new THREE.Mesh(geometry, material)
+    window.cube = cube
     //const cube = new THREE.Mesh( new THREE.SphereGeometry( 0.5, 20, 10 ), material );
     //cube =  new THREE.Mesh( new THREE.TetrahedronGeometry( 0.5, 0 ), material );
-    cube.position.set(2, 1, 0)
+    cube.position.set(5, 1, 0)
 
     app.add(cube)
 
@@ -85,19 +86,15 @@ export default () => {
     const faces2 = res.outFaces.slice(res.numOutFaces[0], res.numOutFaces[0] + res.numOutFaces[1])
 
     const geometry2 = new THREE.BufferGeometry()
-
-    //geometry2.setIndex(faces1);
-    //geometry2.setAttribute('position', positions1);
-
     geometry2.setIndex(new THREE.Uint32BufferAttribute(faces1, 1))
-
     geometry2.setAttribute('position', new THREE.Float32BufferAttribute(positions1, 3))
     geometry2.setAttribute('normal', new THREE.Float32BufferAttribute(normals1, 3))
 
     // const material2 = new THREE.MeshBasicMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
     const material2 = new THREE.MeshStandardMaterial({ color: 0x00ff00, side: THREE.DoubleSide })
     const cube2 = new THREE.Mesh(geometry2, material2)
-    cube2.position.set(-0.2, 1.1, 0)
+    window.cube2 = cube2
+    cube2.position.set(0, 1, 0)
     console.log('geometry2', geometry2)
 
     //debugger;
@@ -109,11 +106,13 @@ export default () => {
     const geometry3 = new THREE.BufferGeometry()
     geometry3.setIndex(new THREE.Uint32BufferAttribute(faces2, 1))
     geometry3.setAttribute('position', new THREE.Float32BufferAttribute(positions2, 3))
+    geometry3.setAttribute('normal', new THREE.Float32BufferAttribute(normals2, 3))
 
     // const material3 = new THREE.MeshBasicMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
     const material3 = new THREE.MeshStandardMaterial({ color: 0x0000ff, side: THREE.DoubleSide })
     const cube3 = new THREE.Mesh(geometry3, material3)
-    cube3.position.set(0.2, 0.9, 0)
+    window.cube3 = cube3
+    cube3.position.set(0, 1, 0)
     console.log('geometry3', geometry3)
 
     app.add(cube3)


### PR DESCRIPTION
Follow & wasm version of https://github.com/webaverse/metaverse-utils/pull/1

Related PR: https://github.com/webaverse/app/pull/2211 , https://github.com/webaverse/app-wasm/pull/19

First usable version MeshCutter wasm.

Need many improvement afterwards, such as:
1. Not hard-code cut `plane`.
2. Use `struct` to make codes less verbose.
3. Do not hard code output alloc length. Try to pass back wasm output length to js.